### PR TITLE
Fix cursor app command not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "nx serve",
+    "start": "nx serve ticket-frontend",
     "build": "nx build concert-ticket-backend",
     "vercel-build": "nx build concert-ticket-backend",
     "test": "nx test",


### PR DESCRIPTION
Update `npm start` script to specify a default project, resolving an issue where `nx serve` hangs in the Cursor app.

The original `npm start` command used `nx serve` without a specific project. When run in the Cursor app environment, this interactive command would hang, preventing the application from starting. By explicitly setting `ticket-frontend` as the default project, the command now executes non-interactively and successfully serves the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f8754b9-0696-4969-8070-900607e6f4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f8754b9-0696-4969-8070-900607e6f4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

