### PR TITLE
fix: Update CI workflow to run with code ready label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,6 @@ on:
     types: [labeled, synchronize, edited]
     branches:
       - main
-    # Зөвхөн манай ticket төсөлд өөрчлөлт орсон тохиолдолд ажиллуулна
-    paths:
-      - 'apps/2j/concert-ticket/**'
-      - 'libs/**'
-      - 'nx.json'
-      - 'tsconfig.base.json'
-      - 'package.json'
-      - '.github/workflows/ci.yml'
 
 permissions:
   id-token: write
@@ -25,7 +17,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: "${{ github.event.label.name == 'PR status: code ready' }}"
+    if: contains(github.event.pull_request.labels.*.name, 'PR status: code ready')
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -50,7 +42,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    if: "${{ github.event.label.name == 'PR status: code ready' }}"
+    if: contains(github.event.pull_request.labels.*.name, 'PR status: code ready')
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -75,7 +67,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    if: "${{ github.event.label.name == 'PR status: code ready' }}"
+    if: contains(github.event.pull_request.labels.*.name, 'PR status: code ready')
     timeout-minutes: 10
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -115,7 +107,7 @@ jobs:
 
   preview-and-E2E:
     runs-on: ubuntu-latest
-    if: "${{ github.event.label.name == 'PR status: code ready' }}"
+    if: contains(github.event.pull_request.labels.*.name, 'PR status: code ready')
     timeout-minutes: 10
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem
The CI workflow was stuck in queue and not running even when the 'PR status: code ready' label was set.

## Root Causes
1. **Label condition issue**: The workflow only checked `github.event.label.name` which only works on `labeled` events, not on `synchronize` (push) or `edited` events
2. **Paths filter**: The workflow was filtered to only run on changes to specific paths, blocking execution on other file changes

## Changes
- ✅ Updated label condition to `contains(github.event.pull_request.labels.*.name, 'PR status: code ready')` to check if label exists on PR regardless of trigger event
- ✅ Removed `paths` filter to allow workflow to run on all file changes
- ✅ Applied fix to all 4 jobs: lint, test, build, preview-and-E2E

## Expected Behavior
The workflow will now:
- Run when the label is added
- Run when commits are pushed (synchronize) if label is present
- Run when PR is edited if label is present
- Work with any file changes in the repository